### PR TITLE
[STEP 17, 18] 대용량 트래픽&데이터 처리

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
 	implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
 	kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.kafka:spring-kafka")
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,31 +1,24 @@
-version: '3'
+version: '3.8'
 services:
   mysql:
-    image: mysql:8.0
-    ports:
-      - "23306:3306"
-    environment:
-      - MYSQL_ROOT_PASSWORD=root
-      - MYSQL_USER=application
-      - MYSQL_PASSWORD=application
-      - MYSQL_DATABASE=hhplus
-    volumes:
-      - ./data/mysql/:/var/lib/mysql
+    extends:
+      file: docker/compose.mysql.yml
+      service: mysql
 
   redis:
-    image: redis:7-alpine
-    ports:
-      - "6379:6379"
-    command: ["redis-server", "--appendonly", "yes", "--requirepass", "redis_pwd"]
-    environment:
-      - TZ=Asia/Seoul
-    volumes:
-      - ./data/redis:/data
-    healthcheck:
-      test: ["CMD", "redis-cli", "-a", "redis_pwd", "PING"]
-      interval: 5s
-      timeout: 3s
-      retries: 20
+    extends:
+      file: docker/compose.redis.yml
+      service: redis
+
+  kafka:
+    extends:
+      file: docker/compose.kafka.yml
+      service: kafka
+
+  kafka-ui:
+    extends:
+      file: docker/compose.kafka-ui.yml
+      service: kafka-ui
 
 networks:
   default:

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,65 @@
+## Docker Compose Conventions
+
+이 프로젝트는 서비스별 Compose 프래그먼트를 분리하여 관리합니다. 루트 `docker-compose.yml`은 필요한 프래그먼트를 `extends`로 가져와 한 번에 기동합니다.
+
+### Naming & Location
+- 파일명: `docker/compose.<name>.yml`
+  - 예: `docker/compose.mysql.yml`, `docker/compose.redis.yml`, `docker/compose.kafka.yml`, `docker/compose.kafka-ui.yml`
+- 원칙: 가능한 한 프래그먼트당 1 서비스. 스택 단위가 필요하면 의미있는 `<name>` 사용(예: `compose.observability.yml`).
+
+### Authoring Guidelines
+- 포트/볼륨 충돌을 피하십시오. 데이터 볼륨은 `${COMPOSE_PROJECT_DIR}/data/<service>`로 통일합니다.
+- 헬스체크를 권장합니다(의존 서비스의 `depends_on.condition`에 활용 가능).
+- 민감정보는 환경변수/개발용 값만 포함하고, 비밀키는 커밋하지 않습니다.
+- 태그는 명시적으로 고정합니다(예: `mysql:8.0`, `redis:7-alpine`, `bitnami/kafka:4.0.0`).
+
+### Running
+- 전체 서비스 기동(루트에서 실행):
+```bash
+docker compose up -d
+```
+- 상태/로그/정지:
+```bash
+docker compose ps
+docker compose logs <service> | cat
+docker compose down
+```
+
+### Selective Run (Examples)
+- 특정 프래그먼트만 선택 실행:
+```bash
+docker compose -f docker-compose.yml -f docker/compose.mysql.yml -f docker/compose.redis.yml up -d
+```
+- PowerShell 세션에서 기본 프래그먼트 묶기:
+```powershell
+$env:COMPOSE_FILE="docker-compose.yml;docker/compose.mysql.yml;docker/compose.redis.yml"
+docker compose up -d
+```
+
+### Adding a New Fragment
+1) `docker/compose.<name>.yml` 파일 생성
+```yaml
+services:
+  <service-name>:
+    image: <vendor>/<image>:<tag>
+    ports:
+      - "<host>:<container>"
+    environment:
+      # 환경변수 필요 시
+    volumes:
+      - ${COMPOSE_PROJECT_DIR}/data/<service-name>:/data
+    healthcheck:
+      # 필요 시 정의
+```
+2) 루트 `docker-compose.yml`에 `extends` 추가:
+```yaml
+services:
+  <service-name>:
+    extends:
+      file: docker/compose.<name>.yml
+      service: <service-name>
+```
+
+### Notes
+- 개발 편의를 위해 일부 프래그먼트는 자동 토픽 생성, PLAINTEXT 등 로컬 지향 설정을 포함할 수 있습니다. 운영 구성과 분리하여 사용하세요.
+

--- a/docker/compose.kafka-ui.yml
+++ b/docker/compose.kafka-ui.yml
@@ -1,0 +1,13 @@
+services:
+  kafka-ui:
+    image: provectuslabs/kafka-ui:latest
+    container_name: kafka-ui
+    ports:
+      - "28080:8080"
+    environment:
+      - KAFKA_CLUSTERS_0_NAME=local
+      - KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS=kafka:29092
+    depends_on:
+      kafka:
+        condition: service_healthy
+

--- a/docker/compose.kafka.yml
+++ b/docker/compose.kafka.yml
@@ -1,0 +1,23 @@
+services:
+  kafka:
+    image: bitnami/kafka:4.0.0
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      - KAFKA_CFG_NODE_ID=1
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093,PLAINTEXT_INTERNAL://:29092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092,PLAINTEXT_INTERNAL://kafka:29092
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_INTERNAL:PLAINTEXT
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT_INTERNAL
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=1@kafka:9093
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - ALLOW_PLAINTEXT_LISTENER=yes
+    healthcheck:
+      test: ["CMD-SHELL","kafka-topics.sh --bootstrap-server localhost:9092 --list | cat"]
+      interval: 10s
+      timeout: 5s
+      retries: 15
+

--- a/docker/compose.mysql.yml
+++ b/docker/compose.mysql.yml
@@ -1,0 +1,13 @@
+services:
+  mysql:
+    image: mysql:8.0
+    ports:
+      - "23306:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_USER=application
+      - MYSQL_PASSWORD=application
+      - MYSQL_DATABASE=hhplus
+    volumes:
+      - ${COMPOSE_PROJECT_DIR}/data/mysql/:/var/lib/mysql
+

--- a/docker/compose.redis.yml
+++ b/docker/compose.redis.yml
@@ -1,0 +1,16 @@
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    command: ["redis-server", "--appendonly", "yes", "--requirepass", "redis_pwd"]
+    environment:
+      - TZ=Asia/Seoul
+    volumes:
+      - ${COMPOSE_PROJECT_DIR}/data/redis:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "redis_pwd", "PING"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+

--- a/docs/issue-#32/kafka-basics.md
+++ b/docs/issue-#32/kafka-basics.md
@@ -1,0 +1,39 @@
+# Kafka Basics
+
+## 목적
+로컬 환경에서 단일 브로커(KRaft) Kafka를 기동하고, 애플리케이션이 주문 생성 이벤트를 Kafka 토픽으로 발행할 수 있도록 최소 구성을 갖춘다.
+
+## 개념 요약
+- Topic / Partition / Offset: 이벤트 스트림 저장 단위, 병렬 처리 단위, 메시지 위치 지표
+- Producer / Consumer / Consumer Group: 발행 / 구독 / 확장성 단위
+- KRaft: Zookeeper 없이 동작하는 Kafka 내부 컨트롤러/브로커 모드
+
+## 로컬 실행
+- `docker compose up -d`
+- Kafka UI: http://localhost:28080
+- 브로커: `localhost:9092`
+
+## 애플리케이션 연동 (최소)
+- 의존성: `org.springframework.kafka:spring-kafka`
+- 설정:
+```yaml
+spring:
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: false
+```
+- 이벤트 발행: `OrderCreated` → 토픽 `order.events`
+
+## 확인 방법
+1) Kafka UI에서 `order.events` 토픽 확인
+2) 주문 생성 플로우 실행
+3) UI에서 메시지 수신 확인 (키: `orderId`)
+
+## 주의
+- 개발 편의상 자동 토픽 생성, PLAINTEXT가 활성화되어 있음(로컬 한정)
+
+

--- a/docs/issue-#32/kafka-design-coupon-queue.md
+++ b/docs/issue-#32/kafka-design-coupon-queue.md
@@ -1,0 +1,110 @@
+# Kafka Design: Coupon & Queue (STEP 18)
+
+## 목표
+- 쿠폰 발급/대기열 관련 시나리오에서 Kafka의 비동기 이벤트 스트림을 활용한다.
+- 도메인 로직의 동기 결과를 유지하면서, 부수 효과/집계/관측은 Kafka 기반으로 분리한다.
+- 최소 구현과 확장 가능성의 균형을 맞춘다.
+
+## 범위
+- 토픽: `order.events`(기존), `coupon.events`(신규 계획)
+- 이벤트(계획): `CouponIssued`, `CouponOutOfStock`
+- 소비(샘플): 인기상품 집계(완료), 쿠폰 이벤트 후속 처리(BI/대시보드 등, 후속)
+
+## 토픽/키/스키마 규칙(권장)
+- 토픽: 소문자, 도메인 중심 복수형. 예) `order.events`, `coupon.events`
+- 키: 이벤트의 자연키(멱등성/파티셔닝 목적). 예) `orderId`, `couponId`
+- 값: 이벤트 객체(JSON 직렬화). 현재는 도메인 이벤트 그대로 발행
+- 헤더(선택): `eventType`, `schemaVersion` → 현재 최소화(미사용)
+
+## 쿠폰: 이벤트 정의(초안)
+- CouponIssued
+```json
+{
+  "eventId": "<uuid>",
+  "occurredAt": "2025-01-01T12:34:56+09:00",
+  "couponId": 123,
+  "userId": 456,
+  "issuedUserCouponId": 789
+}
+```
+- CouponOutOfStock
+```json
+{
+  "eventId": "<uuid>",
+  "occurredAt": "2025-01-01T12:35:12+09:00",
+  "couponId": 123
+}
+```
+
+## 클래스 다이어그램(개념)
+```mermaid
+classDiagram
+Direction LR
+
+class CouponService {
+  +suspend issueCoupon(userId, couponId): UserCoupon
+}
+class DomainEventPublisher
+class KafkaBroker
+class CouponEventProducer
+class CouponEventConsumer
+class CouponPort
+class CouponIssuancePort
+
+CouponService ..> CouponPort : uses
+CouponService ..> CouponIssuancePort : uses
+CouponService ..> DomainEventPublisher : publishes
+DomainEventPublisher ..> CouponEventProducer : forwards
+CouponEventProducer ..> KafkaBroker : send
+KafkaBroker ..> CouponEventConsumer : deliver
+```
+
+## 시퀀스 다이어그램(쿠폰 발급)
+```mermaid
+sequenceDiagram
+    autonumber
+    participant API as API
+    participant SVC as CouponService
+    participant PORT as CouponPort
+    participant ISSUE as CouponIssuancePort
+    participant PUBLISH as DomainEventPublisher
+    participant KAFKA as Kafka
+    participant CONS as CouponEventConsumer
+
+    API->>SVC: 쿠폰 발급 요청 issueCoupon(userId, couponId)
+    SVC->>ISSUE: tryIssue() 호출
+    alt 성공(OK)
+        SVC->>PORT: 발급된 UserCoupon 영속화
+        SVC->>PUBLISH: CouponIssued 이벤트 발행
+        PUBLISH->>KAFKA: coupon.events 토픽으로 전송
+        KAFKA->>CONS: CouponIssued 전달
+    else 재고 부족(OUT_OF_STOCK)
+        SVC-->>API: OutOfStock 예외 반환
+        SVC->>PUBLISH: CouponOutOfStock 이벤트 발행
+        PUBLISH->>KAFKA: coupon.events 토픽으로 전송
+    end
+    API-->>SVC: 응답 (발급된 쿠폰 또는 오류)
+```
+
+## 대기열 모델(간단안)
+- 단일 파티션(초기): 직렬 처리 보장 → 간단성 극대화
+- 멀티 파티션(확장): 파티션 키 = 쿠폰/행사 ID → 동일 리소스 직렬성 유지, 수평 확장 가능
+
+## 멱등성 전략(소비자)
+- 키 기반 처리 상태 저장: `redis.setIfAbsent("evt:processed:{eventId}", 1, ttl=24h)`
+- 처리 전 체크 → 중복 메시지 재처리 방지
+- 장애 시 재시도/리밸런싱에도 안전
+
+## 장애/운영 포인트(요약)
+- DLQ(후순위): 소비 실패를 특정 토픽으로 라우팅해 조사 가능
+- 모니터링: Lag, 처리율, 실패율을 Kafka UI/메트릭으로 확인
+- 설정: AUTO_CREATE_TOPICS_ENABLE는 개발 편의 전용, 운영에서는 명시 생성 권장
+
+## 구현 계획(최소)
+1) `coupon.events` 발행 프로듀서 추가(CouponService에서 발행 지점 연결)
+2) 필요한 경우 컨슈머 샘플 1종 추가(BI용 counter)
+3) 멱등 키 도입(이벤트 ID 기반)
+
+## 현재 상태
+- 주문 이벤트 발행/소비(인기상품 집계) 완료
+- 쿠폰 이벤트는 본 문서 안에 스펙 정의 → 후속 PR에서 단계적 구현

--- a/src/main/kotlin/kr/hhplus/be/server/repository/redis/RedissonIdempotencyAdapter.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/repository/redis/RedissonIdempotencyAdapter.kt
@@ -1,0 +1,23 @@
+package kr.hhplus.be.server.repository.redis
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kr.hhplus.be.server.service.idempotency.IdempotencyPort
+import org.redisson.api.RedissonClient
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+
+@Component
+@ConditionalOnBean(RedissonClient::class)
+class RedissonIdempotencyAdapter(
+    private val redisson: RedissonClient
+) : IdempotencyPort {
+    override suspend fun tryAcquire(key: String, ttl: Duration): Boolean = withContext(Dispatchers.IO) {
+        val bucket = redisson.getBucket<String>(key)
+        bucket.trySet("1", ttl.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+    }
+}
+
+

--- a/src/main/kotlin/kr/hhplus/be/server/service/config/kafka/KafkaConsumerConfig.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/service/config/kafka/KafkaConsumerConfig.kt
@@ -1,0 +1,39 @@
+package kr.hhplus.be.server.service.config.kafka
+
+import kr.hhplus.be.server.service.order.event.OrderCreated
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.core.ConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.support.serializer.JsonDeserializer
+
+@Configuration
+class KafkaConsumerConfig(
+    private val kafkaProperties: KafkaProperties
+) {
+    @Bean
+    fun orderCreatedConsumerFactory(): ConsumerFactory<String, OrderCreated> {
+        val props = HashMap<String, Any>(kafkaProperties.buildConsumerProperties())
+        props[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
+        props[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = JsonDeserializer::class.java
+        val valueDeserializer = JsonDeserializer(OrderCreated::class.java).apply {
+            addTrustedPackages("kr.hhplus.be.server.*")
+            setUseTypeHeaders(false)
+        }
+        return DefaultKafkaConsumerFactory(props, StringDeserializer(), valueDeserializer)
+    }
+
+    @Bean
+    fun orderCreatedKafkaListenerContainerFactory(): ConcurrentKafkaListenerContainerFactory<String, OrderCreated> {
+        val factory = ConcurrentKafkaListenerContainerFactory<String, OrderCreated>()
+        factory.consumerFactory = orderCreatedConsumerFactory()
+        factory.setAutoStartup(true)
+        return factory
+    }
+}
+
+

--- a/src/main/kotlin/kr/hhplus/be/server/service/config/kafka/KafkaProducerConfig.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/service/config/kafka/KafkaProducerConfig.kt
@@ -1,0 +1,44 @@
+package kr.hhplus.be.server.service.config.kafka
+
+import kr.hhplus.be.server.service.order.event.OrderCreated
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.StringSerializer
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.core.DefaultKafkaProducerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.core.ProducerFactory
+import org.springframework.kafka.support.serializer.JsonSerializer
+
+@Configuration
+class KafkaProducerConfig(
+    private val kafkaProperties: KafkaProperties
+) {
+    @Bean
+    fun orderCreatedProducerFactory(): ProducerFactory<String, OrderCreated> {
+        val props = HashMap<String, Any>(kafkaProperties.buildProducerProperties())
+        props[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java
+        props[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = JsonSerializer::class.java
+        props[JsonSerializer.ADD_TYPE_INFO_HEADERS] = false
+        return DefaultKafkaProducerFactory(props)
+    }
+
+    @Bean
+    fun orderCreatedKafkaTemplate(): KafkaTemplate<String, OrderCreated> =
+        KafkaTemplate(orderCreatedProducerFactory())
+
+    @Bean
+    fun genericProducerFactory(): ProducerFactory<String, Any> {
+        val props = HashMap<String, Any>(kafkaProperties.buildProducerProperties())
+        props[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java
+        props[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = JsonSerializer::class.java
+        props[JsonSerializer.ADD_TYPE_INFO_HEADERS] = false
+        return DefaultKafkaProducerFactory(props)
+    }
+
+    @Bean
+    fun genericKafkaTemplate(): KafkaTemplate<String, Any> = KafkaTemplate(genericProducerFactory())
+}
+
+

--- a/src/main/kotlin/kr/hhplus/be/server/service/coupon/event/CouponEventKafkaProducer.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/service/coupon/event/CouponEventKafkaProducer.kt
@@ -1,0 +1,17 @@
+package kr.hhplus.be.server.service.coupon.event
+
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class CouponEventKafkaProducer(
+    private val kafkaTemplate: KafkaTemplate<String, Any>
+) {
+    private val topicName: String = "coupon.events"
+
+    fun publish(eventKey: String, event: Any) {
+        kafkaTemplate.send(topicName, eventKey, event)
+    }
+}
+
+

--- a/src/main/kotlin/kr/hhplus/be/server/service/coupon/event/CouponIssued.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/service/coupon/event/CouponIssued.kt
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.service.coupon.event
+
+import kr.hhplus.be.server.service.event.DomainEvent
+
+/**
+ * 쿠폰이 성공적으로 발급되었음을 나타내는 도메인 이벤트.
+ */
+data class CouponIssued(
+    val couponId: Long,
+    val userId: Long,
+    val issuedUserCouponId: Long
+) : DomainEvent()
+
+

--- a/src/main/kotlin/kr/hhplus/be/server/service/coupon/event/CouponOutOfStock.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/service/coupon/event/CouponOutOfStock.kt
@@ -1,0 +1,12 @@
+package kr.hhplus.be.server.service.coupon.event
+
+import kr.hhplus.be.server.service.event.DomainEvent
+
+/**
+ * 쿠폰 재고가 부족함을 나타내는 도메인 이벤트.
+ */
+data class CouponOutOfStock(
+    val couponId: Long
+) : DomainEvent()
+
+

--- a/src/main/kotlin/kr/hhplus/be/server/service/coupon/service/CouponService.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/service/coupon/service/CouponService.kt
@@ -1,6 +1,9 @@
 package kr.hhplus.be.server.service.coupon.service
 
 import kr.hhplus.be.server.service.coupon.entity.UserCoupon
+import kr.hhplus.be.server.service.coupon.event.CouponIssued
+import kr.hhplus.be.server.service.coupon.event.CouponOutOfStock
+import kr.hhplus.be.server.service.coupon.event.CouponEventKafkaProducer
 import kr.hhplus.be.server.service.coupon.exception.*
 import kr.hhplus.be.server.service.coupon.port.CouponIssuancePort
 import kr.hhplus.be.server.service.coupon.port.CouponIssuanceResult
@@ -22,7 +25,8 @@ class CouponService (
     val couponPort: CouponPort,
     val couponIssuancePort: CouponIssuancePort,
     val requireUserIdExistsUsecase: RequiresUserIdExistsUsecase,
-    val timeProvider: KoreanTimeProvider
+    val timeProvider: KoreanTimeProvider,
+    val couponEventProducer: CouponEventKafkaProducer
     ) : FindUserCouponByIdUsecase,
     UseUserCouponUsecase,
     FindPagedUserCouponsUsecase,
@@ -76,7 +80,14 @@ class CouponService (
         when (decision) {
             CouponIssuanceResult.OK -> { /* proceed */ }
             CouponIssuanceResult.ALREADY_ISSUED -> throw CouponAlreadyIssuedException()
-            CouponIssuanceResult.OUT_OF_STOCK -> throw CouponOutOfStockException()
+            CouponIssuanceResult.OUT_OF_STOCK -> {
+                // 이벤트 발행 (비동기 관측/카운팅 용도)
+                couponEventProducer.publish(
+                    eventKey = couponId.toString(),
+                    event = CouponOutOfStock(couponId = couponId)
+                )
+                throw CouponOutOfStockException()
+            }
             CouponIssuanceResult.NOT_READY -> throw CouponNotReadyException()
         }
 
@@ -88,6 +99,16 @@ class CouponService (
                 couponPort.revokeCoupon(issuedUserCoupon = coupon, now = now)
             }
         }
+
+        // 발급 성공 이벤트 발행
+        couponEventProducer.publish(
+            eventKey = couponId.toString(),
+            event = CouponIssued(
+                couponId = couponId,
+                userId = userId,
+                issuedUserCouponId = issuedUserCoupon.id
+            )
+        )
 
         return issuedUserCoupon
     }

--- a/src/main/kotlin/kr/hhplus/be/server/service/idempotency/IdempotencyPort.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/service/idempotency/IdempotencyPort.kt
@@ -1,0 +1,10 @@
+package kr.hhplus.be.server.service.idempotency
+
+import kotlin.time.Duration
+
+interface IdempotencyPort {
+    /**
+     * 멱등성 키를 TTL과 함께 선점합니다. 이미 존재하면 false를 반환합니다.
+     */
+    suspend fun tryAcquire(key: String, ttl: Duration): Boolean
+}

--- a/src/main/kotlin/kr/hhplus/be/server/service/order/event/OrderCreatedKafkaConsumer.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/service/order/event/OrderCreatedKafkaConsumer.kt
@@ -1,0 +1,56 @@
+package kr.hhplus.be.server.service.order.event
+
+import kr.hhplus.be.server.repository.product.RedisPopularProductSummaryCacheDto
+import kr.hhplus.be.server.service.idempotency.IdempotencyPort
+import kr.hhplus.be.server.service.product.port.PopularProductPort
+import kr.hhplus.be.server.service.transaction.CompensationScope
+import kr.hhplus.be.server.util.KoreanTimeProvider
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.stereotype.Component
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * 주문 생성 이벤트 소비자
+ */
+@Component
+class OrderCreatedKafkaConsumer(
+    private val popularProductPort: PopularProductPort,
+    private val timeProvider: KoreanTimeProvider,
+    private val idempotencyPort: IdempotencyPort,
+    @Value("\${app.idempotency.event-ttl-seconds:86400}") private val idempotencyTtlSeconds: Long
+) {
+    private val processedKeyPrefix = "evt:processed:"
+
+    /**
+     * 인기 상품 카운트 업데이트 (멱등 가드 적용)
+     */
+    @KafkaListener(
+        topics = ["order.events"],
+        containerFactory = "orderCreatedKafkaListenerContainerFactory"
+    )
+    suspend fun onMessage(event: OrderCreated) {
+        val key = processedKeyPrefix + event.eventId.toString()
+        val ttl: Duration = idempotencyTtlSeconds.seconds
+        if (!idempotencyPort.tryAcquire(key, ttl)) return
+
+        val now = timeProvider.now()
+        val maps: List<RedisPopularProductSummaryCacheDto> = event.order.orderItems.map { item ->
+            RedisPopularProductSummaryCacheDto(
+                productId = item.productId.toInt(),
+                soldCount = item.quantity.toInt()
+            )
+        }
+
+        CompensationScope.runTransaction {
+            execute {
+                popularProductPort.increaseProductSoldCount(maps, now)
+            }.compensate {
+                popularProductPort.decreaseProductSoldCount(maps, now)
+            }
+        }
+    }
+}
+
+

--- a/src/main/kotlin/kr/hhplus/be/server/service/order/event/OrderCreatedKafkaProducer.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/service/order/event/OrderCreatedKafkaProducer.kt
@@ -1,0 +1,25 @@
+package kr.hhplus.be.server.service.order.event
+
+import org.springframework.context.event.EventListener
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+
+/**
+ * OrderCreated 도메인 이벤트를 Kafka 토픽으로 포워딩하는 최소 구현.
+ * - 토픽: order.events
+ * - 키: orderId
+ * - 값: OrderCreated (도메인 이벤트 그대로)
+ */
+@Component
+class OrderCreatedKafkaProducer(
+    private val kafkaTemplate: KafkaTemplate<String, OrderCreated>
+) {
+    private val topicName: String = "order.events"
+
+    @EventListener
+    fun onOrderCreated(event: OrderCreated) {
+        val orderId: Long = checkNotNull(event.order.id) { "order.id must not be null when publishing." }
+        //
+        kafkaTemplate.send(topicName, orderId.toString(), event)
+    }
+}

--- a/src/main/kotlin/kr/hhplus/be/server/service/order/event/OrderEventListener.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/service/order/event/OrderEventListener.kt
@@ -1,6 +1,5 @@
 package kr.hhplus.be.server.service.order.event
 
-import kr.hhplus.be.server.repository.product.RedisPopularProductSummaryCacheDto
 import kr.hhplus.be.server.service.order.port.DataPlatformPort
 import kr.hhplus.be.server.service.product.port.PopularProductPort
 import kr.hhplus.be.server.service.transaction.CompensationScope
@@ -9,7 +8,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
-import java.time.ZonedDateTime
 
 @Component
 class OrderEventListener(
@@ -18,33 +16,6 @@ class OrderEventListener(
     private val timeProvider: KoreanTimeProvider
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
-
-    /**
-     * 인기 상품 집계: 주문 생성 정보를 Redis 집계 시스템에 전달
-     */
-    @Async
-    @EventListener
-    suspend fun aggregatePopularProductSalesOnOrderCreated(event: OrderCreated) {
-        runCatching {
-            CompensationScope.runTransaction {
-                val now: ZonedDateTime = timeProvider.now()
-                val maps: List<RedisPopularProductSummaryCacheDto> = event.order.orderItems.map {
-                    RedisPopularProductSummaryCacheDto(
-                        productId = it.productId.toInt(),
-                        soldCount = it.quantity.toInt()
-                    )
-                }
-
-                execute {
-                    popularProductPort.increaseProductSoldCount(maps, now)
-                }.compensate { 
-                    popularProductPort.decreaseProductSoldCount(maps, now)
-                }
-            }
-        }.onFailure { ex ->
-            log.warn("인기상품 집계 처리 실패", ex)
-        }
-    }
 
     /**
      * 데이터 플랫폼 전송: 주문 생성 정보를 외부 데이터 플랫폼에 전달

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,6 +56,10 @@ logging:
     com.zaxxer.hikari: DEBUG
     # 트랜잭션 로깅
     org.springframework.transaction: DEBUG
+
+app:
+  idempotency:
+    event-ttl-seconds: 86400
 springdoc:
   api-docs:
     enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,22 @@ spring:
     port: 6379
     password: redis_pwd
 
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: false
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: "kr.hhplus.be.server.*"
+        spring.json.value.default.type: "kr.hhplus.be.server.service.order.event.OrderCreated"
+      group-id: hhplus-order-consumer
+      auto-offset-reset: latest
+
 # 성능 분석용 로깅 설정
 logging:
   level:

--- a/src/test/java/kr/hhplus/be/server/service/coupon/CouponServiceTest.kt
+++ b/src/test/java/kr/hhplus/be/server/service/coupon/CouponServiceTest.kt
@@ -15,6 +15,7 @@ import kr.hhplus.be.server.service.coupon.exception.UserCouponIsNotUsedButTriedT
 import kr.hhplus.be.server.service.coupon.port.CouponIssuancePort
 import kr.hhplus.be.server.service.coupon.port.CouponIssuanceResult
 import kr.hhplus.be.server.service.coupon.port.CouponPort
+import kr.hhplus.be.server.service.coupon.event.CouponEventKafkaProducer
 import kr.hhplus.be.server.service.coupon.service.CouponService
 import kr.hhplus.be.server.service.pagination.PagedList
 import kr.hhplus.be.server.service.pagination.PagingOptions
@@ -41,6 +42,9 @@ class CouponServiceTest : ServiceTestBase() {
     @MockK
     private lateinit var issuancePort: CouponIssuancePort
 
+    @MockK
+    private lateinit var couponEventProducer: CouponEventKafkaProducer
+
     private lateinit var couponService: CouponService
 
 
@@ -48,11 +52,13 @@ class CouponServiceTest : ServiceTestBase() {
     @BeforeEach
     fun setupCouponService() {
         super.setUp()
+        every { couponEventProducer.publish(any(), any()) } just Runs
         couponService = CouponService(
             couponPort = couponPort,
             couponIssuancePort = issuancePort,
             requireUserIdExistsUsecase = requireUserIdExistsUsecase,
-            timeProvider = timeProvider
+            timeProvider = timeProvider,
+            couponEventProducer = couponEventProducer
         )
     }
 

--- a/src/test/java/kr/hhplus/be/server/service/order/OrderCreatedKafkaConsumerTest.kt
+++ b/src/test/java/kr/hhplus/be/server/service/order/OrderCreatedKafkaConsumerTest.kt
@@ -1,0 +1,96 @@
+package kr.hhplus.be.server.service.order
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import kotlinx.coroutines.test.runTest
+import kr.hhplus.be.server.repository.product.RedisPopularProductSummaryCacheDto
+import kr.hhplus.be.server.service.ServiceTestBase
+import kr.hhplus.be.server.service.order.entity.Order
+import kr.hhplus.be.server.service.order.entity.OrderItem
+import kr.hhplus.be.server.service.order.event.OrderCreated
+import kr.hhplus.be.server.service.order.event.OrderCreatedKafkaConsumer
+import kr.hhplus.be.server.service.product.port.PopularProductPort
+import kr.hhplus.be.server.service.idempotency.IdempotencyPort
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(MockKExtension::class)
+@DisplayName("OrderCreatedKafkaConsumer - 멱등 가드")
+class OrderCreatedKafkaConsumerTest : ServiceTestBase() {
+
+    @MockK
+    lateinit var popularProductPort: PopularProductPort
+
+    @MockK
+    lateinit var idempotencyPort: IdempotencyPort
+
+    private lateinit var consumer: OrderCreatedKafkaConsumer
+
+    @BeforeEach
+    override fun setUp() {
+        super.setUp()
+        consumer = OrderCreatedKafkaConsumer(popularProductPort, timeProvider, idempotencyPort, 86400)
+    }
+
+    @Test
+    @DisplayName("동일 이벤트를 두 번 수신하면, 첫 번째만 처리되고 두 번째는 무시된다")
+    fun 동일_이벤트_두_번_수신_첫번째만_처리() = runTest {
+        // Given
+        val order = Order(
+            id = 1L,
+            userId = 1L,
+            userCouponId = null,
+            orderItems = listOf(OrderItem(id = 1L, productId = 10L, productName = "p", unitPrice = 1000L, quantity = 2)),
+            totalProductsPrice = 2000L,
+            discountedPrice = 0L,
+            orderedAt = fixedTime
+        )
+        val event = OrderCreated(order)
+        val key = "evt:processed:${event.eventId}"
+
+        coEvery { idempotencyPort.tryAcquire(key, any()) } returnsMany listOf(true, false)
+
+        // When
+        consumer.onMessage(event)
+        consumer.onMessage(event)
+
+        // Then
+        coVerify(exactly = 1) {
+            popularProductPort.increaseProductSoldCount(
+                listOf(RedisPopularProductSummaryCacheDto(10, 2)),
+                fixedTime
+            )
+        }
+    }
+
+    @Test
+    @DisplayName("멱등 선점에 실패하면, 집계는 호출되지 않는다")
+    fun 멱등_선점_실패시_집계_호출되지_않음() = runTest {
+        // Given
+        val order = Order(
+            id = 1L,
+            userId = 1L,
+            userCouponId = null,
+            orderItems = listOf(OrderItem(id = 1L, productId = 11L, productName = "p", unitPrice = 1000L, quantity = 1)),
+            totalProductsPrice = 1000L,
+            discountedPrice = 0L,
+            orderedAt = fixedTime
+        )
+        val event = OrderCreated(order)
+        val key = "evt:processed:${event.eventId}"
+
+        coEvery { idempotencyPort.tryAcquire(key, any()) } returns false
+
+        // When
+        consumer.onMessage(event)
+
+        // Then
+        coVerify(exactly = 0) { popularProductPort.increaseProductSoldCount(any(), any()) }
+    }
+}
+
+

--- a/src/test/java/kr/hhplus/be/server/service/order/OrderEventListenerTest.kt
+++ b/src/test/java/kr/hhplus/be/server/service/order/OrderEventListenerTest.kt
@@ -35,30 +35,6 @@ class OrderEventListenerTest : ServiceTestBase() {
     }
 
     @Test
-    @DisplayName("OrderCreated 수신 시 인기상품 집계를 호출한다")
-    fun callsPopularAggregationOnOrderCreated() = runTest {
-        // given
-        val orderItems = listOf(
-            OrderItem(id = 1L, productId = 1L, productName = "아메리카노", unitPrice = 4500L, quantity = 2)
-        )
-        val order = Order(
-            id = 1L,
-            userId = 1L,
-            userCouponId = null,
-            orderItems = orderItems,
-            totalProductsPrice = 9000L,
-            discountedPrice = 0L,
-            orderedAt = fixedTime
-        )
-
-        // when
-        listener.aggregatePopularProductSalesOnOrderCreated(OrderCreated(order))
-
-        // then
-        coVerify { popularProductPort.increaseProductSoldCount(any(), fixedTime) }
-    }
-
-    @Test
     @DisplayName("OrderCreated 수신 시 데이터 플랫폼 전송을 호출한다")
     fun callsDataPlatformOnOrderCreated() = runTest {
         // given

--- a/src/test/java/kr/hhplus/be/server/service/repository/redis/RedissonIdempotencyAdapterTest.kt
+++ b/src/test/java/kr/hhplus/be/server/service/repository/redis/RedissonIdempotencyAdapterTest.kt
@@ -1,0 +1,60 @@
+package kr.hhplus.be.server.service.repository.redis
+
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kr.hhplus.be.server.repository.redis.RedissonIdempotencyAdapter
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.redisson.api.RBucket
+import org.redisson.api.RedissonClient
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
+
+@DisplayName("RedissonIdempotencyAdapter - 멱등 키 선점")
+class RedissonIdempotencyAdapterTest {
+
+    @Test
+    @DisplayName("동일 키를 두 번 선점하면, 첫 번째는 성공이고 두 번째는 실패이다")
+    fun 동일_키_두_번_선점_첫번째_성공_두번째_실패() = runBlocking {
+        // Given
+        val client = mockk<RedissonClient>()
+        val bucket = mockk<RBucket<String>>()
+        every { client.getBucket<String>(any<String>()) } returns bucket
+        every { bucket.trySet(any(), any<Long>(), any<TimeUnit>()) } returnsMany listOf(true, false)
+
+        val adapter = RedissonIdempotencyAdapter(client)
+
+        // When
+        val first = adapter.tryAcquire("k1", 1.seconds)
+        val second = adapter.tryAcquire("k1", 1.seconds)
+
+        // Then
+        assertTrue(first)
+        assertFalse(second)
+    }
+
+    @Test
+    @DisplayName("서로 다른 키를 각각 선점하면, 두 호출 모두 성공이다")
+    fun 서로_다른_키_각각_선점_모두_성공() = runBlocking {
+        // Given
+        val client = mockk<RedissonClient>()
+        val bucket = mockk<RBucket<String>>()
+        every { client.getBucket<String>(any<String>()) } returns bucket
+        every { bucket.trySet(any(), any<Long>(), any<TimeUnit>()) } returns true
+
+        val adapter = RedissonIdempotencyAdapter(client)
+
+        // When
+        val k1 = adapter.tryAcquire("k1", 1.seconds)
+        val k2 = adapter.tryAcquire("k2", 1.seconds)
+
+        // Then
+        assertTrue(k1)
+        assertTrue(k2)
+    }
+}
+
+


### PR DESCRIPTION
## :pushpin: PR 제목 규칙
[STEP 17, 18] 성승현 - e-commerce

---
### STEP 17 카프카 기초 학습 및 활용
- [x] 카프카에 대한 기본 개념 학습 문서 작성
- [x] 실시간 주문/예약 정보를 카프카 메시지로 발행

### STEP 18 카프카를 활용하여 비즈니스 프로세스 개선
- [x] 카프카를 특징을 활용하도록 쿠폰/대기열 설계문서 작성
- [ ] 설계문서대로 카프카를 활용한 기능 구현

### 주요 커밋
- 카프카 안내 문서: b81be1c0792d8318fa0f1387b0b2d6fe626528c0
- 주문 생성
  - 카프카 이벤트 publish 구현: 10c02edfd6406ea8e86dbb7687f5edb5d6fc5d9c
  - 카프카 이벤트 consume 구현: 905ef035bd66d13ca53a2ffa136b59c28a80e0f1
- (WIP) 쿠폰 관련 작업: 056f368c2ce38558073fc0271dc9f963c53af737

### **간단 회고** (3줄 이내)
- **잘한 점**: 도커 컴포즈 파일 관심사별 세분화
- **어려운 점**: 
  - 통합테스트 버전 관리가 안되어서 자꾸 깨짐.. 지속적으로 시도는 해보고 있으나 테스트 컨테이너 호환 버전 등에 대한 버전 히스토리 지식이 선행되어야 하는 지점 같아서 어려움이 크다고 느껴짐
  - 현재 추상화 및 패키지 정리 구조가 점점 스파게티가 되어간다고 느껴짐.. 시간에 쫓길 때 이런 컨벤션까지 같이 챙기는 것이 점점 힘들어지는 데 적절한 타협 지점을 찾을 필요가 있을 듯
  - 쿠폰 발급 카프카 기반 설계 문서는 작성했는 데, 완전 비즈니스 로직에 반영하지는 못함.. 기존 코드가 너무 레디스 기반 구현에 강결합되어 있는 이슈가 있음.. 이럴땐 어케 손대지
- **다음 시도**: 
  - 테스트 컨테이너 안깨지는 범위 내에서 버전을 타협하든지, 돌지 않는 부분에 대해서 통합 테스트 코드를 걷어내든 처리를 해줘야할 것   같음. 
    - 아예 테스트 컨테이너가 필요한 지점만 별도로 컨테이너별로 별개로 통합 테스트 패키지를 만들어서 관리하는 것도 고려 대상